### PR TITLE
Allow broadcast to pass message id for ensuring single receipt of message

### DIFF
--- a/storage/dberror_normalizer.go
+++ b/storage/dberror_normalizer.go
@@ -1,0 +1,16 @@
+package storage
+
+import (
+	"github.com/go-sql-driver/mysql"
+)
+
+func normalizeDBError(mysqlDriverErr error, mappedError map[uint16]error) (err error) {
+	err = mysqlDriverErr
+	if mysqlErr, ok := mysqlDriverErr.(*mysql.MySQLError); ok {
+		err = mysqlErr
+		if mappedErr, ok := mappedError[mysqlErr.Number]; ok {
+			err = mappedErr
+		}
+	}
+	return err
+}

--- a/storage/messagerepo_test.go
+++ b/storage/messagerepo_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/imyousuf/webhook-broker/storage/data"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -163,4 +164,8 @@ func TestMessageSetDispatched(t *testing.T) {
 		tx, _ := testDB.Begin()
 		assert.Equal(t, ErrNoTxInContext, msgRepo.SetDispatched(context.WithValue(context.Background(), ContextKey("hello"), tx), message))
 	})
+}
+
+func TestNormalizeMySQLError(t *testing.T) {
+	assert.Equal(t, ErrDuplicateMessageIDForChannel, normalizeDBError(&mysql.MySQLError{Number: 1062}, mysqlErrorMap))
 }


### PR DESCRIPTION
For this we also ensure to recognize MySQL Duplicate Entry error so that
broadcast can appropriately return `CONFLICT` status to client. So with
this concurrent message writing will also be taken care of.
