### PR TITLE
Fix dispatching a message when there is no consumer for it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.15.8'
+        go-version: '1.17.6'
     - name: Create dist
       run: mkdir ./dist/
     - name: Run Test & Build
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.15.8'
+        go-version: '1.17.6'
     - name: Create dist
       run: mkdir ./dist/
     - name: Install dependencies

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -66,7 +66,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.15.8'
+        go-version: '1.17.6'
     - name: Create dist
       run: mkdir ./dist/
 

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.15.8'
+        go-version: '1.17.6'
     - name: Create dist
       run: mkdir ./dist/
     - name: Get the version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.8-alpine3.13 AS build-env
+FROM golang:1.17.6-alpine3.15 AS build-env
 
 RUN apk update && apk add bash make git
 
@@ -27,7 +27,7 @@ ADD dispatcher ./dispatcher
 RUN make build
 RUN make test
 
-FROM alpine:3.13
+FROM alpine:3.15
 RUN apk update && apk add curl
 WORKDIR /
 COPY --from=build-env /go/src/github.com/imyousuf/webhook-broker/webhook-broker /webhook-broker

--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,9 @@ generate:
 	mockery --name ProducerRepository --structname "MockProducerRepository" --dir "./storage/" --output "./storage" --testonly --outpkg "storage"
 
 dep-tools:
-	go get github.com/google/wire/cmd/wire
+	go install github.com/google/wire/cmd/wire@latest
 ifneq ($(OS),Alpine Linux)
-	go get github.com/golang-migrate/migrate/v4/cmd/migrate
+	go install github.com/golang-migrate/migrate/v4/cmd/migrate@latest
 	go get github.com/vektra/mockery/v2/.../
 endif
 

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -2,10 +2,10 @@
 
 The project build is straight forward using the `Makefile`; just doing `make` should work. Please ensure you have the following installed prior -
 
-1. GoLang 1.15.x
+1. GoLang 1.17.x
 1. GCC with deps (required for SQLite driver compilation)
 
-That should be it. Tested on _Ubuntu 20.04_ with _GoLang 1.15.4_. One of the development assumption (especially in tests) is no configuration file exists in the box in which test is being executed; which means only default configuration shipped with code is applicable.
+That should be it. Tested on _Ubuntu 20.04_ with _GoLang 1.17.6_. One of the development assumption (especially in tests) is no configuration file exists in the box in which test is being executed; which means only default configuration shipped with code is applicable.
 
 Generate Migration script using command as follows from project root -
 

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,18 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.6
 	github.com/rs/xid v1.2.1
 	github.com/rs/zerolog v1.21.0
-	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/stretchr/testify v1.7.0
-	gopkg.in/ini.v1 v1.62.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/smartystreets/goconvey v1.6.4 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
+	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
+	gopkg.in/ini.v1 v1.62.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/imyousuf/webhook-broker
 
-go 1.15
+go 1.17
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -143,7 +143,6 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -170,7 +169,6 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
@@ -231,7 +229,6 @@ github.com/ktrysmt/go-bitbucket v0.6.4/go.mod h1:9u0v3hsd2rqCHRIpbir1oP7F58uo5dq
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
-github.com/lib/pq v1.8.0 h1:9xohqzkUwzR4Ga4ivdTcawVS89YSDVxXMa3xJX3cGzg=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/markbates/pkger v0.15.1/go.mod h1:0JoVlrol20BSywW79rN3kdFFsE5xYM+rSCQDXbLhiuI=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -454,12 +451,10 @@ golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fq
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
-golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e h1:EHBhcS0mlXEAVwNyO2dLfjToGsyY4j24pTs2ScHnX7s=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -515,7 +510,6 @@ golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
@@ -619,7 +613,6 @@ gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/integration-test/Dockerfile
+++ b/integration-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.8-alpine3.13
+FROM golang:1.17.6-alpine3.15
 
 RUN apk update && apk add bash make git
 

--- a/storage/consumerrepo_test.go
+++ b/storage/consumerrepo_test.go
@@ -30,8 +30,8 @@ const (
 )
 
 var (
-	channel1, channel2       *data.Channel // Used by messagerepo_test as well
-	callbackURL, relativeURL *url.URL
+	channel1, channel2, channel3 *data.Channel // Used by messagerepo_test as well
+	callbackURL, relativeURL     *url.URL
 )
 
 func getConsumerRepo() ConsumerRepository {
@@ -44,6 +44,7 @@ func SetupForConsumerTests() {
 	channelRepo := NewChannelRepository(testDB)
 	channel1 = createTestChannel("channel1-for-consumer", "sampletoken", channelRepo)
 	channel2 = createTestChannel("channel2-for-consumer", "sampletoken", channelRepo)
+	channel3 = createTestChannel("channel3-for-no-consumers", "sampletoken", channelRepo)
 	callbackURL = parseTestURL("https://imytech.net/")
 	relativeURL = parseTestURL("./test/")
 }
@@ -333,6 +334,16 @@ func TestConsumerGetList(t *testing.T) {
 		_, _, err := repo.GetList(channel2.ChannelID, data.NewPagination(nil, nil))
 		assert.Equal(t, expectedErr, err)
 		assert.Nil(t, mock.ExpectationsWereMet())
+	})
+	t.Run("EmptyChannel", func(t *testing.T) {
+		t.Parallel()
+		consumers, page, err := repo.GetList(channel3.ChannelID, data.NewPagination(nil, nil))
+		assert.Nil(t, err)
+		assert.NotNil(t, consumers)
+		assert.NotNil(t, page)
+		assert.Equal(t, 0, len(consumers))
+		assert.Nil(t, page.Next)
+		assert.Nil(t, page.Previous)
 	})
 	t.Run("Root", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
Previously when dispatching a message the assumption was there will always
be at least one job created for it; but that is an incorrect assumption in
case of a event bus; so we are gracefully handling it.

Without it the current behavior is no message will be dispatched until the
first consumer is attached, so the first consumer and first consumer alone
would receive all legacy messages, which is inconsistent behavior.

Hence the fix dispatches a message with no delivery job created; so any
new consumer attached to any channel at any sequence and any point of time
will have the DLQ to ingest legacy messages.

Fixes #104

Signed-off-by: Imran M Yousuf <imyousuf@gmail.com>