### PR TITLE
Make github actions be optional for forks

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,11 +40,15 @@ jobs:
         # More details in https://github.com/snyk/actions#getting-your-snyk-token
         # or you can signup for free at https://snyk.io/login
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      if: ${{ env.SNYK_TOKEN != '' }}
       with:
         image: your/image-to-test
         args: --file=Dockerfile
     - name: Upload result to GitHub Code Scanning
       uses: github/codeql-action/upload-sarif@v1
+      env:
+        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      if: ${{ env.SNYK_TOKEN != '' }}
       with:
         sarif_file: snyk.sarif
 

--- a/.github/workflows/helm-build.yml
+++ b/.github/workflows/helm-build.yml
@@ -23,7 +23,7 @@ jobs:
 
   deploy:
 
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && AWS_ACCESS_KEY_ID != ''
 
     needs: [ build ]
 

--- a/.github/workflows/release-containers.yml
+++ b/.github/workflows/release-containers.yml
@@ -33,6 +33,9 @@ jobs:
     -
       uses: docker/login-action@v1
       name: Login to DockerHub
+      env:
+        dockerhub_setup: ${{ secrets.DOCKERHUB_USERNAME }}
+      if: ${{ env.dockerhub_setup != '' }}
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -40,6 +43,9 @@ jobs:
     -
       uses: docker/login-action@v1
       name: Login to Github Docker Registry
+      env:
+        gcr_pat: ${{ secrets.CR_PAT }}
+      if: ${{ env.gcr_pat != '' }}
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
@@ -53,6 +59,10 @@ jobs:
       uses: docker/build-push-action@v2
       name: Push
       id: build_push
+      env:
+        gcr_pat: ${{ secrets.CR_PAT }}
+        dockerhub_setup: ${{ secrets.DOCKERHUB_USERNAME }}
+      if: ${{ env.gcr_pat != '' && env.dockerhub_setup != '' }}
       with:
         push: true
         platforms: linux/amd64,linux/arm64

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,13 @@ OS := $(shell test -f /etc/os-release && cat /etc/os-release | grep '^NAME' | se
 all: clean os-deps dep-tools deps test build
 
 apt-packages:
+	sudo apt-get update
 	sudo apt install --yes gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
 brew-packages:
 
 alpine-packages:
+	apk update
 	apk add --no-cache gcc musl-dev curl
 
 os-deps:

--- a/integration-test/Dockerfile
+++ b/integration-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.3-alpine3.15
+FROM golang:1.19.3-alpine3.17
 
 RUN apk update && apk add bash make git
 


### PR DESCRIPTION
We have several github actions that are meant to be executed only in main repository and not in forks (even if forks choose to execute them); so this change will only make them executable if forks choose as such
